### PR TITLE
Update Go installation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Mapping Format:
 ## Build & Installing
 
 The only requirement to build *knut*: A working go-compiler. Check
-http://golang.org for more information on how to setup one. If you
+https://go.dev for more information on how to setup one. If you
 have a working golang-compiler:
 
     $> go install github.com/mgumz/knut@latest

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The only requirement to build *knut*: A working go-compiler. Check
 https://go.dev for more information on how to setup one. If you
 have a working golang-compiler:
 
-    $> go install github.com/mgumz/knut@latest
+    $> go install github.com/mgumz/knut/cmd/knut@latest
     $> ~/go/bin/knut -h
 
 If you *need* to install something:


### PR DESCRIPTION
Just updated the golang.org link to go.dev.
